### PR TITLE
enable composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
             "name": "Colin Frei",
             "email": "colin.frei@liip.ch"
         }
-    ]
+    ],
+    "autoload": {
+        "psr-4": { "ColinFrei\\BitFieldTypeBundle\\": "" }
+    }
 }


### PR DESCRIPTION
This change enables the bundle to be auto loaded by composer. Otherwise, it needs to be loaded manually.